### PR TITLE
remove early return

### DIFF
--- a/open_url_in_chrome.rb
+++ b/open_url_in_chrome.rb
@@ -8,7 +8,6 @@ url_to_open = ARGV[0]
 def get_profile_with_name(profile_hash, name)
   profile_hash.each do |key, profile|
     return key if profile['name'] == name
-    return nil
   end
 end
 


### PR DESCRIPTION
Having the return there makes it so the `profile_hash.each` block will only check the first pair if it does not match then it will return nil without ever having checked latter pairs